### PR TITLE
(PRICE-383) Search characteristics by alias

### DIFF
--- a/projects/fm-ui-components/src/lib/characteristics-input/characteristics-input.component.html
+++ b/projects/fm-ui-components/src/lib/characteristics-input/characteristics-input.component.html
@@ -15,8 +15,7 @@
   </mat-chip-list>
   <mat-autocomplete #auto="matAutocomplete" (optionSelected)="onValueSelected($event)">
     <mat-option *ngFor="let option of filteredOptions | async" [value]="option">
-      {{option.value.name}}
-      <span *ngIf="option.value.name !== option.characteristic.name">({{option.characteristic.name}})</span>
+      {{option.getDisplayName()}}
     </mat-option>
   </mat-autocomplete>
 </mat-form-field>

--- a/projects/fm-ui-components/src/lib/characteristics-input/characteristics-input.component.html
+++ b/projects/fm-ui-components/src/lib/characteristics-input/characteristics-input.component.html
@@ -3,8 +3,7 @@
     <mat-chip *ngFor="let selected of selectedOptions"
               [selectable]="false"
               (removed)="removeValueFromSelected(selected)">
-      {{selected.value.name}}&nbsp;
-      <span *ngIf="selected.value.name !== selected.characteristic.name">({{selected.characteristic.name}})</span>
+      {{selected.getChipName()}}&nbsp;
       <mat-icon matChipRemove>cancel</mat-icon>
     </mat-chip>
     <input placeholder="Characteristics"
@@ -15,7 +14,7 @@
   </mat-chip-list>
   <mat-autocomplete #auto="matAutocomplete" (optionSelected)="onValueSelected($event)">
     <mat-option *ngFor="let option of filteredOptions | async" [value]="option">
-      {{option.getDisplayName()}}
+      {{option.getSearchName()}}
     </mat-option>
   </mat-autocomplete>
 </mat-form-field>

--- a/projects/fm-ui-components/src/lib/characteristics-input/characteristics-input.component.ts
+++ b/projects/fm-ui-components/src/lib/characteristics-input/characteristics-input.component.ts
@@ -3,35 +3,13 @@ import { FormControl } from '@angular/forms';
 import { Observable } from 'rxjs';
 import { map, startWith } from 'rxjs/operators';
 import { MatAutocompleteSelectedEvent, MatSnackBar } from '@angular/material';
-import { Characteristic, CharacteristicsByType, CharacteristicTypes, IdentifiedCharacteristic } from '../models/characteristic.model';
-import {Value, ValueAlias} from '../models/value.model';
-
-class ValueWithCharacteristic {
-  characteristic: Characteristic;
-  value: Value;
-  alias?: string;
-
-  constructor(char: Characteristic, val: Value) {
-    this.characteristic = char;
-    this.value = val;
-  }
-
-  getDisplayName(): string {
-    let displayName = '';
-    if (this.value.name !== this.characteristic.name) {
-      displayName = `${this.characteristic.name}: ${this.value.name}`;
-    } else {
-      displayName = this.value.name;
-    }
-
-    if (this.alias) {
-      return displayName + ` (${this.alias})`;
-    }
-
-
-    return displayName;
-  }
-}
+import {
+  CharacteristicsByType,
+  CharacteristicTypes,
+  IdentifiedCharacteristic,
+  ValueWithCharacteristic,
+} from '../models/characteristic.model';
+import { ValueAlias } from '../models/value.model';
 
 @Component({
   selector: 'fm-characteristics-input',

--- a/projects/fm-ui-components/src/lib/models/characteristic.model.ts
+++ b/projects/fm-ui-components/src/lib/models/characteristic.model.ts
@@ -36,3 +36,41 @@ export interface IdentifiedCharacteristic {
   value: string;
   type: string;
 }
+
+export class ValueWithCharacteristic {
+  characteristic: Characteristic;
+  value: Value;
+  alias?: string;
+
+  constructor(char: Characteristic, val: Value) {
+    this.characteristic = char;
+    this.value = val;
+  }
+
+  getSearchName(): string {
+    let displayName = '';
+    if (this.value.name !== this.characteristic.name) {
+      displayName = `${this.characteristic.name}: ${this.value.name}`;
+    } else {
+      displayName = this.value.name;
+    }
+
+    if (this.alias) {
+      return displayName + ` (${this.alias})`;
+    }
+
+
+    return displayName;
+  }
+
+  getChipName(): string {
+    let displayName = '';
+    if (this.value.name !== this.characteristic.name) {
+      displayName = `${this.characteristic.name}: ${this.value.name}`;
+    } else {
+      displayName = this.value.name;
+    }
+
+    return displayName;
+  }
+}


### PR DESCRIPTION
### Hygger Story 

[PRICE-383](https://foodmaven.hygger.io/b/163427/t/3486098)

### Overview of Changes

- Allows for search on characteristics by alias in characteristic input
  - An alias will display in the results if the exact alias is typed out
  - However, if you start typing in an alias, the corresponding value will show in the results as well.

Example:

- typing 'ab' will show 'Antibiotic Free'
- typing 'abf' will show 'Antibiotic Free (ABF)


### Checklist

- [x] tests are passing
- [x] build is successful
- [x] PR comments added to guide reviewers, where appropriate

### Reviewers 

- Use with the branch featured in [this](https://github.com/FoodMaven/taxonomy-service/pull/39) PR.
