### PR TITLE
(PRICE-651) Change input placeholder text if read only

### DIFF
--- a/projects/fm-ui-components/src/lib/characteristics-input/characteristics-input.component.html
+++ b/projects/fm-ui-components/src/lib/characteristics-input/characteristics-input.component.html
@@ -7,7 +7,7 @@
       {{selected.getChipName()}}&nbsp;
       <mat-icon matChipRemove>cancel</mat-icon>
     </mat-chip>
-    <input placeholder="Characteristics"
+    <input placeholder="{{getCharacteristicPlaceholder()}}"
            #charInput
            [formControl]="characteristicFormControl"
            [matAutocomplete]="auto"

--- a/projects/fm-ui-components/src/lib/characteristics-input/characteristics-input.component.ts
+++ b/projects/fm-ui-components/src/lib/characteristics-input/characteristics-input.component.ts
@@ -110,6 +110,10 @@ export class CharacteristicsInputComponent implements OnChanges {
 
   }
 
+  getCharacteristicPlaceholder(): string {
+    return this.readOnly ? 'Characteristics' : 'Select characteristics';
+  }
+
   private validateSelectedValue(charValue: ValueWithCharacteristic): boolean {
     let valid = true;
 


### PR DESCRIPTION
### Hygger Story 

[PRICE-651](https://foodmaven.hygger.io/b/163427/t/3765534)

### Overview of Changes

- For the pricing engine, the desire is to have the placeholder text read "Select Characteristics", which may be misleading if the component is in read-only mode. This PR adds functionality to change the placeholder text depending on whether read-only is enable or not

### Checklist

- [x] tests are passing
- [x] build is successful

